### PR TITLE
Update compose for host directories

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,14 @@ services:
       - "1881:5000"
     volumes:
       - .:/app
-      - /WDPassportGabo/recetario_app/instance:/app/instance
+      - /WDPassportGabo/Servicios/Recetario/instance:/app/instance
+      - /WDPassportGabo/Servicios/Recetario/base_de_datos/recetario.db:/app/recetario.db
     environment:
       - FLASK_APP=run.py
     restart: always
+    networks:
+      - nginx_net
+
+networks:
+  nginx_net:
+    external: true


### PR DESCRIPTION
## Summary
- persist instance directory at `/WDPassportGabo/Servicios/Recetario/instance`
- database remains mapped at `/WDPassportGabo/Servicios/Recetario/base_de_datos/recetario.db`
- service uses the external network `nginx_net` and restarts automatically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877c3535a6c833293c0fab02fc4ba35