### PR TITLE
Fix agregar ingrediente feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Abre tu navegador y ve a `http://localhost:1881` para acceder a la aplicación e
 make migrate
 ```
 
+### 4. Persistencia y respaldo de la base de datos
+La base de datos se guarda de forma persistente fuera del contenedor. El archivo
+`recetario.db` se monta en el contenedor desde:
+
+```
+/WDPassportGabo/Servicios/Recetario/base_de_datos/recetario.db
+```
+
+Para realizar un *backup* simplemente copia ese archivo a la ubicación de tu
+preferencia. Asimismo, la carpeta de configuración local se mantiene en
+`/WDPassportGabo/Servicios/Recetario/instance`.
+
 ## Comandos útiles en el Makefile
 
 - **make up**: Construye y levanta los contenedores en segundo plano.

--- a/app/static/js/scripts.js
+++ b/app/static/js/scripts.js
@@ -45,5 +45,32 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // ... resto de tu JS (autores, ingredientes, carta) ...
+  // ------------------- INGREDIENTES DINÁMICOS -------------------
+  const contIngredientes = document.getElementById('ingredientes-container');
+  const btnAgregar = document.getElementById('btn-agregar');
+  if (contIngredientes && btnAgregar) {
+    const addHandlers = (elem) => {
+      const btnRemove = elem.querySelector('.btn-remove');
+      if (btnRemove) {
+        btnRemove.addEventListener('click', () => {
+          elem.remove();
+        });
+      }
+    };
+
+    // inicializar handlers para la primera línea
+    contIngredientes.querySelectorAll('.ingrediente').forEach(addHandlers);
+
+    btnAgregar.addEventListener('click', () => {
+      const base = contIngredientes.querySelector('.ingrediente');
+      if (!base) return;
+      const clone = base.cloneNode(true);
+      clone.querySelectorAll('input').forEach(i => i.value = '');
+      clone.querySelectorAll('select').forEach(s => s.selectedIndex = 0);
+      addHandlers(clone);
+      contIngredientes.appendChild(clone);
+    });
+  }
+
+  // ---------------------------------------------------------------
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,14 @@ services:
       - "1881:5000"
     volumes:
       - .:/app
-      - /WDPassportGabo/recetario_app/instance:/app/instance
+      - /WDPassportGabo/Servicios/Recetario/instance:/app/instance
+      - /WDPassportGabo/Servicios/Recetario/base_de_datos/recetario.db:/app/recetario.db
     environment:
       - FLASK_APP=run.py
     restart: always
+    networks:
+      - nginx_net
+
+networks:
+  nginx_net:
+    external: true


### PR DESCRIPTION
## Summary
- add front-end logic so the "Agregar Ingrediente" button clones the ingredient fields and lets them be removed
- persist database outside the container and document backup path

## Testing
- `make test` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6877c3535a6c833293c0fab02fc4ba35