### PR TITLE
Fix host path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Una aplicación de recetas donde los usuarios pueden consultar, agregar, editar 
 
 ## Estructura de directorios
 
-/WDPassportGabo/app_recetario/
+/srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/
 ├── /app/                 # Lógica de la aplicación Flask
 ├── /instance/            # Configuraciones locales
 ├── /__pycache__/          # Archivos compilados de Python
@@ -57,17 +57,17 @@ La base de datos se guarda de forma persistente fuera del contenedor. El archivo
 `recetario.db` se monta en el contenedor desde:
 
 ```
-/WDPassportGabo/Servicios/Recetario/base_de_datos/recetario.db
+/srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/base_de_datos/recetario.db
 ```
 
 Para realizar un *backup* simplemente copia ese archivo a la ubicación de tu
 preferencia. Asimismo, la carpeta de configuración local se mantiene en
-`/WDPassportGabo/Servicios/Recetario/instance`.
+`/srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/instance`.
 
 ## Comandos útiles en el Makefile
 
 - **make up**: Construye y levanta los contenedores en segundo plano.
-- **make down**: Detiene y elimina los contenedores y volúmenes.
+- **make down**: Detiene los contenedores.
 - **make restart**: Reinicia la aplicación (detiene y vuelve a levantar los contenedores).
 - **make logs**: Muestra los logs del contenedor.
 - **make shell**: Abre una terminal dentro del contenedor.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     ports:
       - "1881:5000"
     volumes:
-      - .:/app
-      - /WDPassportGabo/Servicios/Recetario/instance:/app/instance
-      - /WDPassportGabo/Servicios/Recetario/base_de_datos/recetario.db:/app/recetario.db
+      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario:/app
+      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/instance:/app/instance
+      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/base_de_datos/recetario.db:/app/recetario.db
     environment:
       - FLASK_APP=run.py
     restart: always

--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ up:
 	docker compose up --build -d
 
 down:
-	docker compose down -v
+        docker compose down
 
 logs:
 	docker compose logs -f


### PR DESCRIPTION
## Summary
- map the real host directory in `docker-compose.yml`
- update README paths to match the new host location
- ensure `make down` only stops containers

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877edc3a478833288183aea54755bab