### PR TITLE
Fix DB persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,17 @@ make migrate
 
 ### 4. Persistencia y respaldo de la base de datos
 La base de datos se guarda de forma persistente fuera del contenedor. El archivo
-`recetario.db` se monta en el contenedor desde:
+`recetario.db` se monta desde la carpeta `data` del proyecto mediante el
+`docker-compose.yml`:
 
 ```
-/srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/base_de_datos/recetario.db
+./data/recetario.db:/app/recetario.db
 ```
 
-Para realizar un *backup* simplemente copia ese archivo a la ubicación de tu
-preferencia. Asimismo, la carpeta de configuración local se mantiene en
-`/srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/instance`.
+Antes de levantar los contenedores asegúrate de crear la carpeta `data/` (el
+archivo será generado automáticamente). Para realizar un *backup* simplemente
+copia `data/recetario.db` a la ubicación de tu preferencia. La carpeta de
+configuración local se mantiene en `instance/`.
 
 ## Comandos útiles en el Makefile
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ services:
     ports:
       - "1881:5000"
     volumes:
-      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/app:/app
-      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/run.py:/app/run.py
-      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/instance:/app/instance
-      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/base_de_datos/recetario.db:/app/recetario.db
+      - ./app:/app
+      - ./run.py:/app/run.py
+      - ./instance:/app/instance
+      - ./data/recetario.db:/app/recetario.db
     environment:
       - FLASK_APP=run.py
       - FLASK_ENV=development


### PR DESCRIPTION
## Summary
- mount the database to a local `data/` directory
- document the new database path and backup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687843eaa1488332af4774e2df5c56c9