### PR TITLE
Fix DB persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-ENV FLASK_APP=run.py
+ENV FLASK_APP=app/run.py
 ENV FLASK_ENV=development
 
 CMD ["flask", "run", "--host=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -6,14 +6,12 @@ Una aplicación de recetas donde los usuarios pueden consultar, agregar, editar 
 ## Estructura de directorios
 
 /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/
-├── /app/                 # Lógica de la aplicación Flask
+├── /app/                 # Lógica de la aplicación Flask (incluye `run.py` y `seed.py`)
 ├── /instance/            # Configuraciones locales
 ├── /__pycache__/          # Archivos compilados de Python
 ├── Dockerfile             # Instrucciones para crear la imagen Docker
 ├── docker-compose.yml     # Composición de los contenedores Docker
 ├── requirements.txt       # Dependencias del proyecto
-├── run.py                 # Punto de entrada de la aplicación
-├── seed.py                # Script para cargar datos iniciales
 └── Makefile               # Script para facilitar la gestión del contenedor
 
 ## Requisitos
@@ -54,15 +52,17 @@ make migrate
 
 ### 4. Persistencia y respaldo de la base de datos
 La base de datos se guarda de forma persistente fuera del contenedor. El archivo
-`recetario.db` se monta en el contenedor desde:
+`recetario.db` se monta desde la carpeta `data` del proyecto mediante el
+`docker-compose.yml`:
 
 ```
-/srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/base_de_datos/recetario.db
+./data/recetario.db:/app/recetario.db
 ```
 
-Para realizar un *backup* simplemente copia ese archivo a la ubicación de tu
-preferencia. Asimismo, la carpeta de configuración local se mantiene en
-`/srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/instance`.
+Antes de levantar los contenedores asegúrate de crear la carpeta `data/` (el
+archivo será generado automáticamente). Para realizar un *backup* simplemente
+copia `data/recetario.db` a la ubicación de tu preferencia. La carpeta de
+configuración local se mantiene en `instance/`.
 
 ## Comandos útiles en el Makefile
 

--- a/app/run.py
+++ b/app/run.py
@@ -1,4 +1,4 @@
-from app import create_app
+from . import create_app
 
 app = create_app()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,11 @@ services:
     ports:
       - "1881:5000"
     volumes:
-      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/app:/app
-      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/run.py:/app/run.py
-      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/instance:/app/instance
-      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/base_de_datos/recetario.db:/app/recetario.db
+      - ./app:/app
+      - ./instance:/app/instance
+      - ./data/recetario.db:/app/recetario.db
     environment:
-      - FLASK_APP=run.py
+      - FLASK_APP=app/run.py
       - FLASK_ENV=development
     restart: always
     networks:


### PR DESCRIPTION
## Summary
- mount the database to a local `data/` directory
- document the new database path and backup instructions
- move `run.py` into `app/` and update configs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687843eaa1488332af4774e2df5c56c9