### PR TITLE
Fix flask import error by mounting entire repo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "1881:5000"
     volumes:
-      - ./app:/app
+      - ./:/app
       - ./instance:/app/instance
       - ../baseDatos:/app/baseDatos  # <--- cambio clave: persistencia fuera del contenedor
     environment:


### PR DESCRIPTION
## Summary
- mount the whole repo into the Docker container instead of just the `app` folder

This keeps the `app` package path intact so `FLASK_APP=app/run.py` is found.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68787845c5048332bc11ddede19240c4