### PR TITLE
Fix docker build by ignoring data folders

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Exclude persistent data volumes from build context
+# These directories are mounted into containers and should not be copied
+# during Docker image build. Ignoring them also avoids permission errors
+# when the host user lacks access to their contents.
+
+data/
+__pycache__/
+*.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@ docker-compose.override.yml
 
 # Base de datos y volúmenes
 data/
-baseDatos/
-!baseDatos/.gitkeep
+!data/db/.gitkeep
+!data/images/.gitkeep
 db/
 volumes/
 instance/

--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@
 
 Una aplicación de recetas donde los usuarios pueden consultar, agregar, editar y eliminar recetas.
 
+La versión actual de la aplicación utiliza **PostgreSQL** como base de datos en lugar de SQLite. Todo se ejecuta dentro de contenedores Docker para facilitar la configuración y la persistencia de los datos.
+
 ## Estructura de directorios
 
 /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/Recetario/recetario/
 ├── /app/                 # Lógica de la aplicación Flask (incluye `run.py` y `seed.py`)
 ├── /instance/            # Configuraciones locales
-├── /baseDatos/           # Base de datos SQLite persistente
+├── /data/
+│   ├── /db/              # Datos persistentes de PostgreSQL
+│   └── /images/          # Carpeta para imágenes
 ├── /__pycache__/          # Archivos compilados de Python
 ├── Dockerfile             # Instrucciones para crear la imagen Docker
 ├── docker-compose.yml     # Composición de los contenedores Docker
@@ -54,18 +58,18 @@ make migrate
 ```
 
 ### 4. Persistencia y respaldo de la base de datos
-La base de datos se guarda de forma persistente fuera del contenedor. El archivo
-`recetario.db` se monta desde la carpeta `baseDatos` del proyecto mediante el
-`docker-compose.yml`:
+La aplicación utiliza PostgreSQL como base de datos, ejecutada en un contenedor
+separado. Los datos se almacenan en la carpeta `data/db/` de este proyecto.
+Dentro del contenedor se usa la variable `PGDATA` para guardar la información en
+`/var/lib/postgresql/data/pgdata`, de modo que `data/db/` puede contener archivos
+de mantenimiento (como `.gitkeep`) sin interferir con la base de datos.
 
-```
-./baseDatos:/app/baseDatos
-```
+Para realizar un *backup* basta con copiar el contenido de `data/db/` o emplear
+las herramientas de respaldo de PostgreSQL según tus necesidades. La carpeta de
+configuración local sigue estando en `instance/`.
 
-Antes de levantar los contenedores asegúrate de crear la carpeta `baseDatos/` (el
-archivo será generado automáticamente). Para realizar un *backup* simplemente
-copia `baseDatos/recetario.db` a la ubicación de tu preferencia. La carpeta de
-configuración local se mantiene en `instance/`.
+Adicionalmente, las imágenes que suba la aplicación se almacenarán en
+`data/images/`, por lo que también puedes respaldar esa carpeta si la utilizas.
 
 ## Comandos útiles en el Makefile
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,7 +12,12 @@ def create_app():
     app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'dev_secret_key')
 
     # Configuración de la URI de la base de datos
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///baseDatos/recetario.db'
+    # Por defecto se conecta al contenedor "db" definido en docker-compose.
+    database_url = os.getenv(
+        'DATABASE_URL',
+        'postgresql://recetario:recetario@db:5432/recetario'
+    )
+    app.config['SQLALCHEMY_DATABASE_URI'] = database_url
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
     # Habilitar modo de desarrollo y depuración

--- a/data/db/.gitkeep
+++ b/data/db/.gitkeep
@@ -1,0 +1,1 @@
+keep db directory

--- a/data/images/.gitkeep
+++ b/data/images/.gitkeep
@@ -1,0 +1,1 @@
+keep images directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,26 @@ services:
     volumes:
       - ./:/app
       - ./instance:/app/instance
-      - ./baseDatos:/app/baseDatos  # base de datos persistente
+      - ./data/images:/app/images
     environment:
       - FLASK_APP=app/run.py
       - FLASK_ENV=development
+      - DATABASE_URL=postgresql://recetario:recetario@db:5432/recetario
+    depends_on:
+      - db
     restart: always
+    networks:
+      - nginx_net
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: recetario
+      POSTGRES_USER: recetario
+      POSTGRES_PASSWORD: recetario
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - ./data/db:/var/lib/postgresql/data
     networks:
       - nginx_net
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.3.3
 Flask-SQLAlchemy==3.1.1
+psycopg2-binary==2.9.9


### PR DESCRIPTION
## Summary
- add `.dockerignore` to exclude persistent `data/` directories from the Docker build context

## Testing
- `make test` *(fails: `docker: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6878fc0ec34c83328e550703084a93d4