### PR TITLE
Add recipe image support

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,12 @@ def create_app():
 
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
+    # Carpeta para subir imágenes
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    image_dir = os.path.join(base_dir, 'images')
+    os.makedirs(image_dir, exist_ok=True)
+    app.config['IMAGE_UPLOADS'] = image_dir
+
     # Habilitar modo de desarrollo y depuración
     app.config['FLASK_ENV'] = 'development'  # Configura el entorno como desarrollo
     app.config['DEBUG'] = True  # Habilita la depuración

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -40,4 +40,12 @@ body {
   cursor: pointer;
 }
 
+/* Galería de imágenes */
+.galeria-thumb {
+  width: 1in;
+  height: 1in;
+  object-fit: cover;
+  cursor: pointer;
+}
+
 /* El resto de tu CSS queda igual... */

--- a/app/static/js/scripts.js
+++ b/app/static/js/scripts.js
@@ -72,5 +72,20 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  // ------------------- GALERÍA DE IMÁGENES --------------------
+  const thumbs = document.querySelectorAll('#galeria img');
+  const modalElem = document.getElementById('imagenModal');
+  const carouselElem = document.getElementById('galeriaCarousel');
+  if (thumbs.length && modalElem && carouselElem) {
+    const modal = new bootstrap.Modal(modalElem);
+    const carousel = new bootstrap.Carousel(carouselElem);
+    thumbs.forEach((img, idx) => {
+      img.addEventListener('click', () => {
+        carousel.to(idx);
+        modal.show();
+      });
+    });
+  }
+
   // ---------------------------------------------------------------
 });

--- a/app/templates/crear_receta_independiente.html
+++ b/app/templates/crear_receta_independiente.html
@@ -5,7 +5,7 @@
 {% block content %}
   <h1 class="mb-4">Nueva Receta</h1>
 
-  <form method="POST" id="form-receta" data-api-autores="{{ url_for('main.api_autores') }}">
+  <form method="POST" enctype="multipart/form-data" id="form-receta" data-api-autores="{{ url_for('main.api_autores') }}">
     <div class="row g-3 mb-4">
       <div class="col-md-8">
         <input type="text" id="nombre" name="nombre" class="form-control" placeholder="Nombre de la Receta" required>
@@ -50,8 +50,14 @@
       <button type="button" class="btn btn-secondary" id="btn-agregar">Agregar Ingrediente</button>
     </div>
 
+
     <div class="mb-4">
       <textarea id="metodo" name="metodo" class="form-control" rows="5" placeholder="Método de Preparación" required></textarea>
+    </div>
+
+    <div class="mb-4">
+      <label for="imagenes" class="form-label">Imágenes del proceso</label>
+      <input type="file" id="imagenes" name="imagenes" class="form-control" accept="image/*" multiple capture="environment">
     </div>
 
     <div class="d-grid mb-4">

--- a/app/templates/mostrar_receta.html
+++ b/app/templates/mostrar_receta.html
@@ -44,6 +44,41 @@
     </div>
   {% endif %}
 
+  {% if imagenes %}
+    <div class="mb-4">
+      <h5>Imágenes</h5>
+      <div class="d-flex flex-wrap gap-2" id="galeria">
+        {% for img in imagenes %}
+          <img src="{{ url_for('main.images', filename=img) }}" class="img-thumbnail galeria-thumb" data-index="{{ loop.index0 }}" alt="Imagen {{ loop.index }}">
+        {% endfor %}
+      </div>
+
+      <div class="modal fade" id="imagenModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-lg">
+          <div class="modal-content">
+            <div class="modal-body p-0">
+              <div id="galeriaCarousel" class="carousel slide" data-bs-ride="false">
+                <div class="carousel-inner">
+                  {% for img in imagenes %}
+                  <div class="carousel-item {% if loop.first %}active{% endif %}">
+                    <img src="{{ url_for('main.images', filename=img) }}" class="d-block w-100" alt="Imagen {{ loop.index }}">
+                  </div>
+                  {% endfor %}
+                </div>
+                <button class="carousel-control-prev" type="button" data-bs-target="#galeriaCarousel" data-bs-slide="prev">
+                  <span class="carousel-control-prev-icon"></span>
+                </button>
+                <button class="carousel-control-next" type="button" data-bs-target="#galeriaCarousel" data-bs-slide="next">
+                  <span class="carousel-control-next-icon"></span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
   <div class="d-flex gap-2">
   <a href="{{ url_for('main.ver_recetas') }}" class="btn btn-secondary">Todas las Recetas</a>
   <a href="{{ url_for('main.index') }}" class="btn btn-outline-secondary">Volver al Buscador</a>


### PR DESCRIPTION
## Summary
- configure image directory in flask app
- handle image upload and save per recipe
- serve uploaded images and display gallery
- allow image files on recipe creation form
- add modal carousel gallery with JS

## Testing
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68791accbe88833292d610e753833cac