### PR TITLE
Implement image preview and capture on recipe form

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -48,4 +48,11 @@ body {
   cursor: pointer;
 }
 
+/* Vista previa de subida de imágenes */
+.preview-thumb {
+  width: 1in;
+  height: 1in;
+  object-fit: cover;
+}
+
 /* El resto de tu CSS queda igual... */

--- a/app/static/js/scripts.js
+++ b/app/static/js/scripts.js
@@ -88,4 +88,49 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // ---------------------------------------------------------------
+
+  // ------------------- PREVIA DE SUBIDA DE IMÁGENES -------------
+  const inputImagenes = document.getElementById('imagenes');
+  const preview = document.getElementById('preview');
+  const btnCapturar = document.getElementById('btn-capturar');
+  const capturaInput = document.getElementById('capture-input');
+  let archivosSeleccionados = [];
+
+  const actualizarInput = () => {
+    const dt = new DataTransfer();
+    archivosSeleccionados.forEach(f => dt.items.add(f));
+    if (inputImagenes) {
+      inputImagenes.files = dt.files;
+    }
+  };
+
+  const agregarArchivos = (files) => {
+    Array.from(files).forEach(file => {
+      if (!file.type.startsWith('image/')) return;
+      archivosSeleccionados.push(file);
+      if (preview) {
+        const img = document.createElement('img');
+        img.className = 'img-thumbnail preview-thumb';
+        img.src = URL.createObjectURL(file);
+        preview.appendChild(img);
+      }
+    });
+    actualizarInput();
+  };
+
+  if (inputImagenes) {
+    inputImagenes.addEventListener('change', (e) => {
+      agregarArchivos(e.target.files);
+      inputImagenes.value = '';
+    });
+  }
+
+  if (btnCapturar && capturaInput) {
+    btnCapturar.addEventListener('click', () => capturaInput.click());
+    capturaInput.addEventListener('change', (e) => {
+      agregarArchivos(e.target.files);
+      capturaInput.value = '';
+    });
+  }
+
 });

--- a/app/templates/crear_receta_independiente.html
+++ b/app/templates/crear_receta_independiente.html
@@ -57,7 +57,12 @@
 
     <div class="mb-4">
       <label for="imagenes" class="form-label">Imágenes del proceso</label>
-      <input type="file" id="imagenes" name="imagenes" class="form-control" accept="image/*" multiple>
+      <div class="input-group">
+        <input type="file" id="imagenes" name="imagenes" class="form-control" accept="image/*" multiple>
+        <button type="button" class="btn btn-outline-secondary" id="btn-capturar">Tomar foto</button>
+        <input type="file" id="capture-input" accept="image/*" capture="environment" style="display:none">
+      </div>
+      <div id="preview" class="d-flex flex-wrap gap-2 mt-2"></div>
     </div>
 
     <div class="d-grid mb-4">


### PR DESCRIPTION
## Summary
- allow capturing and uploading multiple images when creating recipes
- preview selected images and append new selections to the preview

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68792cc127bc833288b779d13499756b