### PR TITLE
Remove redundant home link from create recipe screen

### DIFF
--- a/app/templates/crear_receta_independiente.html
+++ b/app/templates/crear_receta_independiente.html
@@ -70,9 +70,6 @@
     </div>
   </form>
 
-  <div>
-    <a href="{{ url_for('main.index') }}" class="link-secondary">Volver a la página principal</a>
-  </div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- remove the extra "Volver a la página principal" link from the create recipe page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6879307351788332be3ac7575580a02c