### PR TITLE
Implement removable preview images

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -48,4 +48,35 @@ body {
   cursor: pointer;
 }
 
+/* Vista previa de subida de imágenes */
+.preview-thumb {
+  width: 1in;
+  height: 1in;
+  object-fit: cover;
+}
+
+.preview-container {
+  position: relative;
+  display: inline-block;
+}
+
+.preview-remove {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 1.2rem;
+  height: 1.2rem;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.75rem;
+  line-height: 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
 /* El resto de tu CSS queda igual... */

--- a/app/static/js/scripts.js
+++ b/app/static/js/scripts.js
@@ -88,4 +88,70 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // ---------------------------------------------------------------
+
+  // ------------------- PREVIA DE SUBIDA DE IMÁGENES -------------
+  const inputImagenes = document.getElementById('imagenes');
+  const preview = document.getElementById('preview');
+  const btnCapturar = document.getElementById('btn-capturar');
+  const capturaInput = document.getElementById('capture-input');
+  let archivosSeleccionados = [];
+
+  const actualizarInput = () => {
+    const dt = new DataTransfer();
+    archivosSeleccionados.forEach(f => dt.items.add(f));
+    if (inputImagenes) {
+      inputImagenes.files = dt.files;
+    }
+  };
+
+  const renderPreviews = () => {
+    if (!preview) return;
+    preview.innerHTML = '';
+    archivosSeleccionados.forEach((file, idx) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'preview-container';
+      const img = document.createElement('img');
+      img.className = 'img-thumbnail preview-thumb';
+      const url = URL.createObjectURL(file);
+      img.src = url;
+      img.onload = () => URL.revokeObjectURL(url);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'preview-remove';
+      btn.innerHTML = '&times;';
+      btn.addEventListener('click', () => {
+        archivosSeleccionados.splice(idx, 1);
+        renderPreviews();
+        actualizarInput();
+      });
+      wrapper.appendChild(img);
+      wrapper.appendChild(btn);
+      preview.appendChild(wrapper);
+    });
+  };
+
+  const agregarArchivos = (files) => {
+    Array.from(files).forEach(file => {
+      if (!file.type.startsWith('image/')) return;
+      archivosSeleccionados.push(file);
+    });
+    renderPreviews();
+    actualizarInput();
+  };
+
+  if (inputImagenes) {
+    inputImagenes.addEventListener('change', (e) => {
+      agregarArchivos(e.target.files);
+      inputImagenes.value = '';
+    });
+  }
+
+  if (btnCapturar && capturaInput) {
+    btnCapturar.addEventListener('click', () => capturaInput.click());
+    capturaInput.addEventListener('change', (e) => {
+      agregarArchivos(e.target.files);
+      capturaInput.value = '';
+    });
+  }
+
 });

--- a/app/templates/crear_receta_independiente.html
+++ b/app/templates/crear_receta_independiente.html
@@ -57,7 +57,12 @@
 
     <div class="mb-4">
       <label for="imagenes" class="form-label">Imágenes del proceso</label>
-      <input type="file" id="imagenes" name="imagenes" class="form-control" accept="image/*" multiple>
+      <div class="input-group">
+        <input type="file" id="imagenes" name="imagenes" class="form-control" accept="image/*" multiple>
+        <button type="button" class="btn btn-outline-secondary" id="btn-capturar">Tomar foto</button>
+        <input type="file" id="capture-input" accept="image/*" capture="environment" style="display:none">
+      </div>
+      <div id="preview" class="d-flex flex-wrap gap-2 mt-2"></div>
     </div>
 
     <div class="d-grid mb-4">


### PR DESCRIPTION
## Summary
- allow removing individual images from the preview area when creating recipes
- update JavaScript to re-render previews with a delete button for each image
- style preview containers and delete buttons for better UX

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68792cc127bc833288b779d13499756b