### PR TITLE
Enable editing and deleting recipes

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -113,3 +113,69 @@ def ver_recetas():
         mensaje = f"No se encontraron resultados para '{query}'. Mostrando todas las recetas."  
     recetas = Receta.query.all()
     return render_template('recetas.html', recetas=recetas, mensaje=mensaje)
+
+@main.route('/receta/<int:id>/editar', methods=['GET', 'POST'])
+def editar_receta(id):
+    receta = Receta.query.get_or_404(id)
+    carpeta = os.path.join(current_app.config['IMAGE_UPLOADS'], str(id))
+    if request.method == 'POST':
+        nombre = request.form.get('nombre', '').strip()
+        autor = request.form.get('autor', '').strip()
+        descripcion = request.form.get('descripcion', '').strip()
+        metodo = request.form.get('metodo', '').strip()
+        if not nombre or not autor or not metodo:
+            return "Por favor, complete todos los campos", 400
+        receta.nombre = nombre
+        receta.autor = autor
+        receta.descripcion = descripcion
+        receta.metodo = metodo
+        # Actualizar ingredientes
+        Ingrediente.query.filter_by(receta_id=receta.id).delete()
+        ingredientes_data = request.form.getlist('ingredientes[]')
+        cantidades_data = request.form.getlist('cantidades[]')
+        unidades_data = request.form.getlist('unidades[]')
+        for i in range(len(ingredientes_data)):
+            ing = Ingrediente(
+                nombre=ingredientes_data[i],
+                cantidad=cantidades_data[i],
+                unidad=unidades_data[i],
+                receta_id=receta.id
+            )
+            db.session.add(ing)
+        # Eliminar imágenes seleccionadas
+        eliminar = request.form.getlist('eliminar_imagenes')
+        for relpath in eliminar:
+            path = os.path.join(current_app.config['IMAGE_UPLOADS'], relpath)
+            if os.path.isfile(path):
+                os.remove(path)
+        # Guardar nuevas imágenes
+        archivos = request.files.getlist('imagenes')
+        if archivos:
+            os.makedirs(carpeta, exist_ok=True)
+            for f in archivos:
+                if f and allowed_file(f.filename):
+                    nombre_seguro = secure_filename(f.filename)
+                    f.save(os.path.join(carpeta, nombre_seguro))
+        db.session.commit()
+        return redirect(url_for('main.ver_recetas'))
+
+    imagenes = []
+    if os.path.isdir(carpeta):
+        for nombre in os.listdir(carpeta):
+            if allowed_file(nombre):
+                imagenes.append(f"{id}/{nombre}")
+    imagenes.sort()
+    return render_template('editar_receta.html', receta=receta, imagenes=imagenes)
+
+
+@main.route('/receta/<int:id>/eliminar', methods=['POST'])
+def eliminar_receta(id):
+    receta = Receta.query.get_or_404(id)
+    db.session.delete(receta)
+    db.session.commit()
+    carpeta = os.path.join(current_app.config['IMAGE_UPLOADS'], str(id))
+    if os.path.isdir(carpeta):
+        import shutil
+        shutil.rmtree(carpeta)
+    flash('Receta eliminada correctamente')
+    return redirect(url_for('main.ver_recetas'))

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -79,4 +79,14 @@ body {
   padding: 0;
 }
 
+/* Small square icon buttons */
+.icon-btn {
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* El resto de tu CSS queda igual... */

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,6 +7,8 @@
   <title>{% block title %}Recetario{% endblock %}</title>
   <!-- Bootstrap 5 CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Bootstrap Icons -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.min.css" rel="stylesheet">
   <!-- Custom Styles -->
   <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
   {% block head %}{% endblock %}

--- a/app/templates/editar_receta.html
+++ b/app/templates/editar_receta.html
@@ -1,0 +1,93 @@
+{% extends 'base.html' %}
+
+{% block title %}Editar Receta{% endblock %}
+
+{% block content %}
+  <h1 class="mb-4">Editar Receta</h1>
+
+  <form method="POST" enctype="multipart/form-data" id="form-receta" data-api-autores="{{ url_for('main.api_autores') }}">
+    <div class="row g-3 mb-4">
+      <div class="col-md-8">
+        <input type="text" id="nombre" name="nombre" class="form-control" placeholder="Nombre de la Receta" required value="{{ receta.nombre }}">
+      </div>
+      <div class="col-md-4 position-relative">
+        <input type="text" id="autor" name="autor" class="form-control" placeholder="Autor" autocomplete="off" required value="{{ receta.autor }}">
+        <div id="resultados_autores" class="list-group position-absolute w-100 mt-1"></div>
+      </div>
+    </div>
+
+    <div class="mb-4">
+      <textarea id="descripcion" name="descripcion" class="form-control" rows="2" placeholder="Descripción breve">{{ receta.descripcion }}</textarea>
+    </div>
+
+    <div id="ingredientes-container" class="mb-4">
+      {% for ing in receta.ingredientes %}
+      <div class="row g-2 align-items-end mb-2 ingrediente">
+        <div class="col-md-5">
+          <input type="text" name="ingredientes[]" class="form-control" placeholder="Ingrediente" required value="{{ ing.nombre }}">
+        </div>
+        <div class="col-md-3">
+          <input type="number" name="cantidades[]" class="form-control" placeholder="Cantidad" required value="{{ ing.cantidad }}">
+        </div>
+        <div class="col-md-3">
+          <select name="unidades[]" class="form-select">
+            <option value="gramos" {% if ing.unidad == 'gramos' %}selected{% endif %}>Gramos</option>
+            <option value="kilogramos" {% if ing.unidad == 'kilogramos' %}selected{% endif %}>Kilogramos</option>
+            <option value="ml" {% if ing.unidad == 'ml' %}selected{% endif %}>Mililitros</option>
+            <option value="litros" {% if ing.unidad == 'litros' %}selected{% endif %}>Litros</option>
+            <option value="unidad" {% if ing.unidad == 'unidad' %}selected{% endif %}>Unidad</option>
+            <option value="puñado" {% if ing.unidad == 'puñado' %}selected{% endif %}>Puñado</option>
+            <option value="taza" {% if ing.unidad == 'taza' %}selected{% endif %}>Taza</option>
+            <option value="cucharada" {% if ing.unidad == 'cucharada' %}selected{% endif %}>Cucharada</option>
+            <option value="cucharadita" {% if ing.unidad == 'cucharadita' %}selected{% endif %}>Cucharadita</option>
+          </select>
+        </div>
+        <div class="col-md-1 text-end">
+          <button type="button" class="btn btn-outline-danger btn-remove" title="Eliminar ingrediente">&times;</button>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    <div class="mb-4">
+      <button type="button" class="btn btn-secondary" id="btn-agregar">Agregar Ingrediente</button>
+    </div>
+
+    <div class="mb-4">
+      <textarea id="metodo" name="metodo" class="form-control" rows="5" placeholder="Método de Preparación" required>{{ receta.metodo }}</textarea>
+    </div>
+
+    {% if imagenes %}
+    <div class="mb-4">
+      <label class="form-label">Imágenes actuales</label>
+      <div class="d-flex flex-wrap gap-2">
+        {% for img in imagenes %}
+        <label class="form-check-label position-relative">
+          <img src="{{ url_for('main.images', filename=img) }}" class="img-thumbnail preview-thumb">
+          <input class="form-check-input position-absolute top-0 start-0" type="checkbox" name="eliminar_imagenes" value="{{ img }}" style="transform: scale(1.3);">
+        </label>
+        {% endfor %}
+      </div>
+      <small class="text-muted">Marca las imágenes que deseas eliminar</small>
+    </div>
+    {% endif %}
+
+    <div class="mb-4">
+      <label for="imagenes" class="form-label">Agregar imágenes</label>
+      <div class="input-group">
+        <input type="file" id="imagenes" name="imagenes" class="form-control" accept="image/*" multiple>
+        <button type="button" class="btn btn-outline-secondary" id="btn-capturar">Tomar foto</button>
+        <input type="file" id="capture-input" accept="image/*" capture="environment" style="display:none">
+      </div>
+      <div id="preview" class="d-flex flex-wrap gap-2 mt-2"></div>
+    </div>
+
+    <div class="d-grid mb-4">
+      <button type="submit" class="btn btn-success btn-lg">Editar Receta</button>
+    </div>
+  </form>
+
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+{% endblock %}

--- a/app/templates/recetas.html
+++ b/app/templates/recetas.html
@@ -10,13 +10,23 @@
   <div class="row">
     {% for receta in recetas %}
       <div class="col-md-4 mb-3">
-        <div class="card h-100">
+        <div class="card h-100 position-relative">
           <div class="card-body">
             <h5 class="card-title">{{ receta.nombre }}</h5>
             {% if receta.descripcion %}
               <p class="card-text">{{ receta.descripcion }}</p>
             {% endif %}
-            <a href="{{ url_for('main.mostrar_receta', id=receta.id) }}" class="btn btn-primary">Ver Receta</a>
+            <a href="{{ url_for('main.mostrar_receta', id=receta.id) }}" class="btn btn-primary btn-sm w-100">Ver Receta</a>
+            <div class="position-absolute top-0 end-0 d-flex flex-column gap-2 p-1">
+              <a href="{{ url_for('main.editar_receta', id=receta.id) }}" class="btn btn-success btn-sm icon-btn" title="Editar">
+                <i class="bi bi-pencil"></i>
+              </a>
+              <form method="POST" action="{{ url_for('main.eliminar_receta', id=receta.id) }}" onsubmit="return confirm('¿Eliminar esta receta?');">
+                <button type="submit" class="btn btn-danger btn-sm icon-btn" title="Eliminar">
+                  <i class="bi bi-x"></i>
+                </button>
+              </form>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add edit and delete endpoints in `routes.py`
- provide `editar_receta.html` to edit recipes and manage images
- show Edit and Delete buttons on recipe list
- style recipe list with bootstrap icon buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687933a6a7d08332aec9fcb774a655f1