### PR TITLE
Fix image volume mount path

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ configuración local sigue estando en `instance/`.
 
 Adicionalmente, las imágenes que suba la aplicación se almacenarán en
 `data/images/`, por lo que también puedes respaldar esa carpeta si la utilizas.
+Esta carpeta del host se monta en el contenedor como `/app/data/images`,
+asegurando que las imágenes persistan aunque se reinicie el servicio.
 
 ## Comandos útiles en el Makefile
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./:/app
       - ./instance:/app/instance
-      - ./data/images:/app/images
+      - ./data/images:/app/data/images
     environment:
       - FLASK_APP=app/run.py
       - FLASK_ENV=development


### PR DESCRIPTION
## Summary
- ensure uploaded images persist by mounting volume to `/app/data/images`
- document image volume in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68793dda00788332a4d93c4a9f629bf8