### PR TITLE
Fix image uploads & add cancel button

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -82,6 +82,8 @@ def crear_receta():
 
         # Guardar imágenes si se subieron
         archivos = request.files.getlist('imagenes')
+        if not archivos:
+            archivos = request.files.getlist('imagenes[]')
         if archivos:
             carpeta = os.path.join(current_app.config['IMAGE_UPLOADS'], str(receta.id))
             os.makedirs(carpeta, exist_ok=True)
@@ -150,6 +152,8 @@ def editar_receta(id):
                 os.remove(path)
         # Guardar nuevas imágenes
         archivos = request.files.getlist('imagenes')
+        if not archivos:
+            archivos = request.files.getlist('imagenes[]')
         if archivos:
             os.makedirs(carpeta, exist_ok=True)
             for f in archivos:

--- a/app/templates/crear_receta_independiente.html
+++ b/app/templates/crear_receta_independiente.html
@@ -58,7 +58,7 @@
     <div class="mb-4">
       <label for="imagenes" class="form-label">Imágenes del proceso</label>
       <div class="input-group">
-        <input type="file" id="imagenes" name="imagenes" class="form-control" accept="image/*" multiple>
+        <input type="file" id="imagenes" name="imagenes[]" class="form-control" accept="image/*" multiple>
         <button type="button" class="btn btn-outline-secondary" id="btn-capturar">Tomar foto</button>
         <input type="file" id="capture-input" accept="image/*" capture="environment" style="display:none">
       </div>

--- a/app/templates/editar_receta.html
+++ b/app/templates/editar_receta.html
@@ -76,16 +76,18 @@
     <div class="mb-4">
       <label for="imagenes" class="form-label">Agregar imágenes</label>
       <div class="input-group">
-        <input type="file" id="imagenes" name="imagenes" class="form-control" accept="image/*" multiple>
+        <input type="file" id="imagenes" name="imagenes[]" class="form-control" accept="image/*" multiple>
         <button type="button" class="btn btn-outline-secondary" id="btn-capturar">Tomar foto</button>
         <input type="file" id="capture-input" accept="image/*" capture="environment" style="display:none">
       </div>
       <div id="preview" class="d-flex flex-wrap gap-2 mt-2"></div>
     </div>
 
-    <div class="d-grid mb-4">
+    <div class="d-grid mb-2">
       <button type="submit" class="btn btn-success btn-lg">Editar Receta</button>
-
+    </div>
+    <div class="d-grid mb-4">
+      <a href="{{ url_for('main.ver_recetas') }}" class="btn btn-secondary btn-lg">Cancelar</a>
     </div>
   </form>
 


### PR DESCRIPTION
## Summary
- ensure uploaded files are read regardless of form field name
- update forms to use `imagenes[]` and show cancel button on edit page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687944a089ac833292ab282c1496a06f