### PR TITLE
Configurar Postgres en puerto 5433

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,7 @@ def create_app():
     # Por defecto se conecta al contenedor "db" definido en docker-compose.
     database_url = os.getenv(
         'DATABASE_URL',
-        'postgresql://recetario:recetario@db:5432/recetario'
+        'postgresql://recetario:recetario@db:5433/recetario'
     )
     app.config['SQLALCHEMY_DATABASE_URI'] = database_url
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     environment:
       - FLASK_APP=app/run.py
       - FLASK_ENV=development
-      - DATABASE_URL=postgresql://recetario:recetario@db:5432/recetario
+      - DATABASE_URL=postgresql://recetario:recetario@db:5433/recetario
     depends_on:
       - db
     restart: always
@@ -21,6 +21,9 @@ services:
 
   db:
     image: postgres:15-alpine
+    command: -p 5433
+    ports:
+      - "5433:5433"
     environment:
       POSTGRES_DB: recetario
       POSTGRES_USER: recetario


### PR DESCRIPTION
## Summary
- expose Postgres on port 5433
- update DATABASE_URL to use port 5433

## Testing
- `make test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879599480cc833298ae61b7e1f52151