### PR TITLE
Handle image save errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Adicionalmente, las imágenes que suba la aplicación se almacenarán en
 `data/images/`, por lo que también puedes respaldar esa carpeta si la utilizas.
 Esta carpeta del host se monta en el contenedor como `/app/data/images`,
 asegurando que las imágenes persistan aunque se reinicie el servicio.
+Asegúrate de que la aplicación tenga permisos de escritura en `data/images/`.
 
 ## Comandos útiles en el Makefile
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -96,7 +96,11 @@ def crear_receta():
             for f in archivos:
                 if f and allowed_file(f.filename):
                     nombre_seguro = secure_filename(f.filename)
-                    f.save(os.path.join(carpeta, nombre_seguro))
+                    try:
+                        f.save(os.path.join(carpeta, nombre_seguro))
+                    except OSError as err:
+                        current_app.logger.error(f"Error al guardar {nombre_seguro}: {err}")
+                        flash("Error al guardar imágenes")
 
         return redirect(url_for('main.ver_recetas'))
     return render_template('crear_receta_independiente.html')
@@ -163,7 +167,11 @@ def editar_receta(id):
             for f in archivos:
                 if f and allowed_file(f.filename):
                     nombre_seguro = secure_filename(f.filename)
-                    f.save(os.path.join(carpeta, nombre_seguro))
+                    try:
+                        f.save(os.path.join(carpeta, nombre_seguro))
+                    except OSError as err:
+                        current_app.logger.error(f"Error al guardar {nombre_seguro}: {err}")
+                        flash("Error al guardar imágenes")
         db.session.commit()
         return redirect(url_for('main.ver_recetas'))
 


### PR DESCRIPTION
## Summary
- catch `OSError` when saving uploaded images
- inform user with a flash message and log the error
- document write permission requirements for `data/images/`

## Testing
- `python -m py_compile app/routes.py app/__init__.py app/models.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796b59d52c833293e46ee92992dbb9