### PR TITLE
Implement manual image upload handling

### DIFF
--- a/app/static/js/scripts.js
+++ b/app/static/js/scripts.js
@@ -95,15 +95,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const preview = document.getElementById('preview');
   const btnCapturar = document.getElementById('btn-capturar');
   const capturaInput = document.getElementById('capture-input');
+  const formReceta = document.getElementById('form-receta');
   let archivosSeleccionados = [];
-
-  const actualizarInput = () => {
-    const dt = new DataTransfer();
-    archivosSeleccionados.forEach(f => dt.items.add(f));
-    if (inputImagenes) {
-      inputImagenes.files = dt.files;
-    }
-  };
   const renderPreviews = () => {
     if (!preview) return;
     preview.innerHTML = '';
@@ -122,7 +115,6 @@ document.addEventListener('DOMContentLoaded', () => {
       btn.addEventListener('click', () => {
         archivosSeleccionados.splice(idx, 1);
         renderPreviews();
-        actualizarInput();
       });
       wrapper.appendChild(img);
       wrapper.appendChild(btn);
@@ -136,8 +128,6 @@ document.addEventListener('DOMContentLoaded', () => {
       archivosSeleccionados.push(file);
     });
     renderPreviews();
-
-    actualizarInput();
   };
 
   if (inputImagenes) {
@@ -157,7 +147,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // ------------------- ELIMINAR IMÁGENES EXISTENTES -------------
   const contActuales = document.getElementById('imagenes-actuales');
-  const formReceta = document.getElementById('form-receta');
   if (contActuales && formReceta) {
     contActuales.querySelectorAll('.eliminar-imagen').forEach(btn => {
       btn.addEventListener('click', () => {
@@ -169,6 +158,37 @@ document.addEventListener('DOMContentLoaded', () => {
         input.value = btn.dataset.img;
         formReceta.appendChild(input);
       });
+    });
+  }
+
+  if (formReceta) {
+    formReceta.addEventListener('submit', (e) => {
+      e.preventDefault();
+
+      console.log('🧾 Enviando manualmente...');
+      console.log('Archivos seleccionados:', archivosSeleccionados);
+
+      const formData = new FormData(formReceta);
+
+      archivosSeleccionados.forEach((file) => {
+        formData.append('imagenes[]', file);
+      });
+
+      fetch(formReceta.action, {
+        method: 'POST',
+        body: formData,
+      })
+      .then(res => {
+        if (res.redirected) {
+          window.location.href = res.url;
+        } else {
+          return res.text();
+        }
+      })
+      .then(data => {
+        if (data) console.log('Respuesta del servidor:', data);
+      })
+      .catch(err => console.error('Error al enviar:', err));
     });
   }
 

--- a/app/templates/crear_receta_independiente.html
+++ b/app/templates/crear_receta_independiente.html
@@ -58,7 +58,7 @@
     <div class="mb-4">
       <label for="imagenes" class="form-label">Imágenes del proceso</label>
       <div class="input-group">
-        <input type="file" id="imagenes" name="imagenes[]" class="form-control" accept="image/*" multiple>
+        <input type="file" id="imagenes" class="form-control" accept="image/*" multiple>
         <button type="button" class="btn btn-outline-secondary" id="btn-capturar">Tomar foto</button>
         <input type="file" id="capture-input" accept="image/*" capture="environment" style="display:none">
       </div>

--- a/app/templates/editar_receta.html
+++ b/app/templates/editar_receta.html
@@ -76,7 +76,7 @@
     <div class="mb-4">
       <label for="imagenes" class="form-label">Agregar imágenes</label>
       <div class="input-group">
-        <input type="file" id="imagenes" name="imagenes[]" class="form-control" accept="image/*" multiple>
+        <input type="file" id="imagenes" class="form-control" accept="image/*" multiple>
         <button type="button" class="btn btn-outline-secondary" id="btn-capturar">Tomar foto</button>
         <input type="file" id="capture-input" accept="image/*" capture="environment" style="display:none">
       </div>


### PR DESCRIPTION
## Summary
- remove `name` attribute from image inputs in forms
- refactor `scripts.js` to preview files without touching `input.files`
- submit recipe forms via `fetch` with `FormData`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879c7c7ee948332946685e44320f7c3