### PR TITLE
Add loading overlay on recipe forms

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -89,4 +89,22 @@ body {
   justify-content: center;
 }
 
+/* Overlay shown while submitting forms */
+.form-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.7);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.form-overlay.active {
+  display: flex;
+}
+
 /* El resto de tu CSS queda igual... */

--- a/app/static/js/scripts.js
+++ b/app/static/js/scripts.js
@@ -96,6 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnCapturar = document.getElementById('btn-capturar');
   const capturaInput = document.getElementById('capture-input');
   const formReceta = document.getElementById('form-receta');
+  const overlay = document.getElementById('loading-overlay');
   let archivosSeleccionados = [];
   const renderPreviews = () => {
     if (!preview) return;
@@ -165,6 +166,10 @@ document.addEventListener('DOMContentLoaded', () => {
     formReceta.addEventListener('submit', (e) => {
       e.preventDefault();
 
+      if (overlay) {
+        overlay.classList.add('active');
+      }
+
       console.log('🧾 Enviando manualmente...');
       console.log('Archivos seleccionados:', archivosSeleccionados);
 
@@ -187,8 +192,16 @@ document.addEventListener('DOMContentLoaded', () => {
       })
       .then(data => {
         if (data) console.log('Respuesta del servidor:', data);
+        if (overlay) {
+          overlay.classList.remove('active');
+        }
       })
-      .catch(err => console.error('Error al enviar:', err));
+      .catch(err => {
+        console.error('Error al enviar:', err);
+        if (overlay) {
+          overlay.classList.remove('active');
+        }
+      });
     });
   }
 

--- a/app/templates/crear_receta_independiente.html
+++ b/app/templates/crear_receta_independiente.html
@@ -5,7 +5,7 @@
 {% block content %}
   <h1 class="mb-4">Nueva Receta</h1>
 
-  <form method="POST" enctype="multipart/form-data" id="form-receta" data-api-autores="{{ url_for('main.api_autores') }}">
+  <form method="POST" enctype="multipart/form-data" id="form-receta" data-api-autores="{{ url_for('main.api_autores') }}" class="position-relative">
     <div class="row g-3 mb-4">
       <div class="col-md-8">
         <input type="text" id="nombre" name="nombre" class="form-control" placeholder="Nombre de la Receta" required>
@@ -67,6 +67,11 @@
 
     <div class="d-grid mb-4">
       <button type="submit" class="btn btn-primary btn-lg">Crear Receta</button>
+    </div>
+    <div id="loading-overlay" class="form-overlay">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Cargando...</span>
+      </div>
     </div>
   </form>
 

--- a/app/templates/editar_receta.html
+++ b/app/templates/editar_receta.html
@@ -5,7 +5,7 @@
 {% block content %}
   <h1 class="mb-4">Editar Receta</h1>
 
-  <form method="POST" enctype="multipart/form-data" id="form-receta" data-api-autores="{{ url_for('main.api_autores') }}">
+  <form method="POST" enctype="multipart/form-data" id="form-receta" data-api-autores="{{ url_for('main.api_autores') }}" class="position-relative">
     <div class="row g-3 mb-4">
       <div class="col-md-8">
         <input type="text" id="nombre" name="nombre" class="form-control" placeholder="Nombre de la Receta" required value="{{ receta.nombre }}">
@@ -85,6 +85,11 @@
 
     <div class="d-grid mb-2">
       <button type="submit" class="btn btn-success btn-lg">Editar Receta</button>
+    </div>
+    <div id="loading-overlay" class="form-overlay">
+      <div class="spinner-border text-success" role="status">
+        <span class="visually-hidden">Cargando...</span>
+      </div>
     </div>
     <div class="d-grid mb-4">
       <a href="{{ url_for('main.ver_recetas') }}" class="btn btn-secondary btn-lg">Cancelar</a>


### PR DESCRIPTION
## Summary
- block editing and creation forms with overlay spinner while submitting
- style overlay in CSS
- trigger overlay in submission JS handler

## Testing
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a731736588332a107f8483559a8ae