### PR TITLE
Improve ingredient row mobile layout

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -108,3 +108,13 @@ body {
 }
 
 /* El resto de tu CSS queda igual... */
+
+@media (max-width: 576px) {
+  #ingredientes-container .ingrediente {
+    border-bottom: 1px solid #dee2e6;
+    padding-bottom: 0.5rem;
+  }
+  #ingredientes-container .ingrediente:last-child {
+    border-bottom: 0;
+  }
+}

--- a/app/templates/crear_receta_independiente.html
+++ b/app/templates/crear_receta_independiente.html
@@ -22,27 +22,31 @@
 
     <div id="ingredientes-container" class="mb-4">
       <div class="row g-2 align-items-end mb-2 ingrediente">
-        <div class="col-md-5">
+        <div class="col-12 col-md-5">
           <input type="text" name="ingredientes[]" class="form-control" placeholder="Ingrediente" required>
         </div>
-        <div class="col-md-3">
-          <input type="number" name="cantidades[]" class="form-control" placeholder="Cantidad" required>
-        </div>
-        <div class="col-md-3">
-          <select name="unidades[]" class="form-select">
-            <option value="gramos">Gramos</option>
-            <option value="kilogramos">Kilogramos</option>
-            <option value="ml">Mililitros</option>
-            <option value="litros">Litros</option>
-            <option value="unidad">Unidad</option>
-            <option value="puñado">Puñado</option>
-            <option value="taza">Taza</option>
-            <option value="cucharada">Cucharada</option>
-            <option value="cucharadita">Cucharadita</option>
-          </select>
-        </div>
-        <div class="col-md-1 text-end">
-          <button type="button" class="btn btn-outline-danger btn-remove" title="Eliminar ingrediente">&times;</button>
+        <div class="col-12 col-md-7">
+          <div class="row g-2">
+            <div class="col-4 col-md-5">
+              <input type="number" name="cantidades[]" class="form-control" placeholder="Cantidad" required>
+            </div>
+            <div class="col-5 col-md-5">
+              <select name="unidades[]" class="form-select">
+                <option value="gramos">Gramos</option>
+                <option value="kilogramos">Kilogramos</option>
+                <option value="ml">Mililitros</option>
+                <option value="litros">Litros</option>
+                <option value="unidad">Unidad</option>
+                <option value="puñado">Puñado</option>
+                <option value="taza">Taza</option>
+                <option value="cucharada">Cucharada</option>
+                <option value="cucharadita">Cucharadita</option>
+              </select>
+            </div>
+            <div class="col-3 col-md-2 text-end">
+              <button type="button" class="btn btn-outline-danger btn-remove" title="Eliminar ingrediente">&times;</button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/templates/editar_receta.html
+++ b/app/templates/editar_receta.html
@@ -23,27 +23,31 @@
     <div id="ingredientes-container" class="mb-4">
       {% for ing in receta.ingredientes %}
       <div class="row g-2 align-items-end mb-2 ingrediente">
-        <div class="col-md-5">
+        <div class="col-12 col-md-5">
           <input type="text" name="ingredientes[]" class="form-control" placeholder="Ingrediente" required value="{{ ing.nombre }}">
         </div>
-        <div class="col-md-3">
-          <input type="number" name="cantidades[]" class="form-control" placeholder="Cantidad" required value="{{ ing.cantidad }}">
-        </div>
-        <div class="col-md-3">
-          <select name="unidades[]" class="form-select">
-            <option value="gramos" {% if ing.unidad == 'gramos' %}selected{% endif %}>Gramos</option>
-            <option value="kilogramos" {% if ing.unidad == 'kilogramos' %}selected{% endif %}>Kilogramos</option>
-            <option value="ml" {% if ing.unidad == 'ml' %}selected{% endif %}>Mililitros</option>
-            <option value="litros" {% if ing.unidad == 'litros' %}selected{% endif %}>Litros</option>
-            <option value="unidad" {% if ing.unidad == 'unidad' %}selected{% endif %}>Unidad</option>
-            <option value="puñado" {% if ing.unidad == 'puñado' %}selected{% endif %}>Puñado</option>
-            <option value="taza" {% if ing.unidad == 'taza' %}selected{% endif %}>Taza</option>
-            <option value="cucharada" {% if ing.unidad == 'cucharada' %}selected{% endif %}>Cucharada</option>
-            <option value="cucharadita" {% if ing.unidad == 'cucharadita' %}selected{% endif %}>Cucharadita</option>
-          </select>
-        </div>
-        <div class="col-md-1 text-end">
-          <button type="button" class="btn btn-outline-danger btn-remove" title="Eliminar ingrediente">&times;</button>
+        <div class="col-12 col-md-7">
+          <div class="row g-2">
+            <div class="col-4 col-md-5">
+              <input type="number" name="cantidades[]" class="form-control" placeholder="Cantidad" required value="{{ ing.cantidad }}">
+            </div>
+            <div class="col-5 col-md-5">
+              <select name="unidades[]" class="form-select">
+                <option value="gramos" {% if ing.unidad == 'gramos' %}selected{% endif %}>Gramos</option>
+                <option value="kilogramos" {% if ing.unidad == 'kilogramos' %}selected{% endif %}>Kilogramos</option>
+                <option value="ml" {% if ing.unidad == 'ml' %}selected{% endif %}>Mililitros</option>
+                <option value="litros" {% if ing.unidad == 'litros' %}selected{% endif %}>Litros</option>
+                <option value="unidad" {% if ing.unidad == 'unidad' %}selected{% endif %}>Unidad</option>
+                <option value="puñado" {% if ing.unidad == 'puñado' %}selected{% endif %}>Puñado</option>
+                <option value="taza" {% if ing.unidad == 'taza' %}selected{% endif %}>Taza</option>
+                <option value="cucharada" {% if ing.unidad == 'cucharada' %}selected{% endif %}>Cucharada</option>
+                <option value="cucharadita" {% if ing.unidad == 'cucharadita' %}selected{% endif %}>Cucharadita</option>
+              </select>
+            </div>
+            <div class="col-3 col-md-2 text-end">
+              <button type="button" class="btn btn-outline-danger btn-remove" title="Eliminar ingrediente">&times;</button>
+            </div>
+          </div>
         </div>
       </div>
       {% endfor %}


### PR DESCRIPTION
## Summary
- group quantity, unit and remove button fields under a nested row
- keep ingredient name on first row so inputs wrap correctly on small screens
- add a divider between ingredient rows on mobile for easier reading

## Testing
- `make test` *(fails: `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`)*

------
https://chatgpt.com/codex/tasks/task_e_687a7c644f688332bf414d60abf91317