### PR TITLE
Fix table creation order

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -45,13 +45,6 @@ def create_app():
         from .routes import main  # Blueprint principal
         app.register_blueprint(main)
 
-        # Crear usuario administrador por defecto
-        from .models import Usuario
-        if not Usuario.query.filter_by(is_admin=True).first():
-            admin = Usuario(nombre='admin', password_hash=generate_password_hash('admin'), is_admin=True)
-            db.session.add(admin)
-            db.session.commit()
-
         # Crear las tablas si aún no existen
         try:
             db.create_all()
@@ -59,6 +52,13 @@ def create_app():
             _tables_created = True
         except Exception as e:
             app.logger.error(f"Error al crear las tablas: {e}")
+
+        # Crear usuario administrador por defecto
+        from .models import Usuario
+        if not Usuario.query.filter_by(is_admin=True).first():
+            admin = Usuario(nombre='admin', password_hash=generate_password_hash('admin'), is_admin=True)
+            db.session.add(admin)
+            db.session.commit()
 
     def _ensure_tables_exist():
         """Intenta crear las tablas si aún no fueron creadas."""


### PR DESCRIPTION
## Summary
- create DB tables before checking for admin user
- keep `_ensure_tables_exist` hook for requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac4efee0c8332b0e4e5173b47ba4c