### PR TITLE
Fix recipe card button layout

### DIFF
--- a/app/templates/recetas.html
+++ b/app/templates/recetas.html
@@ -10,28 +10,32 @@
   <div class="row">
     {% for receta in recetas %}
       <div class="col-md-4 mb-3">
-        <div class="card h-100 position-relative">
-          <div class="card-body">
-            <h5 class="card-title">{{ receta.nombre }}</h5>
+        <div class="card h-100">
+          <div class="card-body d-flex flex-column">
+            <div class="d-flex justify-content-between align-items-start mb-2">
+              <h5 class="card-title mb-0">{{ receta.nombre }}</h5>
+              {% if session.get('user_id') and (session.get('is_admin') or session.get('user_id') == receta.usuario_id) %}
+              <div class="d-flex gap-2">
+                <a href="{{ url_for('main.editar_receta', id=receta.id) }}" class="btn btn-success btn-sm icon-btn" title="Editar">
+                  <i class="bi bi-pencil"></i>
+                </a>
+                <form method="POST" action="{{ url_for('main.eliminar_receta', id=receta.id) }}" onsubmit="return confirm('¿Eliminar esta receta?');" class="d-inline">
+                  <button type="submit" class="btn btn-danger btn-sm icon-btn" title="Eliminar">
+                    <i class="bi bi-x"></i>
+                  </button>
+                </form>
+              </div>
+              {% endif %}
+            </div>
             {% if receta.descripcion %}
               <p class="card-text">{{ receta.descripcion }}</p>
             {% endif %}
-            <a href="{{ url_for('main.mostrar_receta', id=receta.id) }}" class="btn btn-primary btn-sm w-100">Ver Receta</a>
-            <div class="position-absolute top-0 end-0 d-flex flex-column gap-2 p-1">
-              {% if session.get('user_id') and (session.get('is_admin') or session.get('user_id') == receta.usuario_id) %}
-              <a href="{{ url_for('main.editar_receta', id=receta.id) }}" class="btn btn-success btn-sm icon-btn" title="Editar">
-                <i class="bi bi-pencil"></i>
-              </a>
-              <form method="POST" action="{{ url_for('main.eliminar_receta', id=receta.id) }}" onsubmit="return confirm('¿Eliminar esta receta?');">
-                <button type="submit" class="btn btn-danger btn-sm icon-btn" title="Eliminar">
-                  <i class="bi bi-x"></i>
-                </button>
-              </form>
+            <div class="mt-auto">
+              <a href="{{ url_for('main.mostrar_receta', id=receta.id) }}" class="btn btn-primary btn-sm w-100">Ver Receta</a>
               {% if session.get('is_admin') %}
-              <button type="button" class="btn btn-secondary btn-sm icon-btn" data-bs-toggle="modal" data-bs-target="#cfg{{ receta.id }}" title="Configurar">
+              <button type="button" class="btn btn-secondary btn-sm icon-btn w-100 mt-2" data-bs-toggle="modal" data-bs-target="#cfg{{ receta.id }}" title="Configurar">
                 <i class="bi bi-gear"></i>
               </button>
-              {% endif %}
               {% endif %}
             </div>
             {% if session.get('is_admin') %}


### PR DESCRIPTION
## Summary
- reorganize layout of action buttons in `recetas.html`
- place edit/delete buttons beside the title
- move configuration button below the main recipe link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ae5d9f0548332824fb800028f995f